### PR TITLE
Fix apex chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ now:
   label: now
 series:
   - entity: sensor.london_bridge_tower_pier_tide
-    extend_to_end: false
     unit: m
     data_generator: |
       return entity.attributes.predictions.map((event) => {


### PR DESCRIPTION
The latest apex charts version does not have `extend_to_end`
Fixes #14 