### PR TITLE
Ensure that LowWater data populates the next_low_tide_at value

### DIFF
--- a/custom_components/ukho_tides/sensor.py
+++ b/custom_components/ukho_tides/sensor.py
@@ -180,7 +180,8 @@ class UkhoTidesSensor(CoordinatorEntity):
                     "tidal_event_datetime"
                 ].astimezone()
                 self._attrs[f"next_high_tide_height"] = f"{next_height}m"
-            else:
+
+            if next_predictions[i]["tidal_event"].event_type == "LowWater":
                 self._attrs[f"next_low_tide_in"] = f"{hours}h {minutes}m"
                 self._attrs[f"next_low_tide_at"] = next_predictions[i][
                     "tidal_event_datetime"


### PR DESCRIPTION
When the station doesn't have low tide data, then the next two tide events are both high tide events, and thus the sensor ends up with the second high tide event overwriting the first one.

This happens following the release of the underlying library to cope with stations without low tide data.

Thanks @ianByrne :) 