### PR TITLE
Update ukhotides to 1.1.2

### DIFF
--- a/custom_components/ukho_tides/manifest.json
+++ b/custom_components/ukho_tides/manifest.json
@@ -3,8 +3,8 @@
   "name": "UKHO Tides",
   "config_flow": true,
   "documentation": "https://github.com/ianByrne/HASS_Integration_UKHOTides",
-  "requirements": ["ukhotides==1.1.1"],
+  "requirements": ["ukhotides==1.1.2"],
   "dependencies": [],
   "codeowners": ["@ianByrne"],
-  "version": "1.1.1"
+  "version": "1.1.2"
 }


### PR DESCRIPTION
**Do not merge until upstream PR has been merged and released**

Hopefully fixes #32 (which is now tracking the integration not working with Home Assistant 2024.12; although the original issue I believe was something else). This requires https://github.com/ianByrne/PyPI-ukhotides/pull/3 to be merged and released. Full disclosure I do not have a Python3.13 developer enviroment set up running Home Assistant at the moment so this is NOT fully tested, although the change is hopefully so minor I can't see there being a problem. The upstream change has been tested.